### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,4 +1,6 @@
 name: Pylint
+permissions:
+  contents: read
 
 on: [push]
 


### PR DESCRIPTION
Potential fix for [https://github.com/RuslanSemchenko/SSRF-Scanner/security/code-scanning/1](https://github.com/RuslanSemchenko/SSRF-Scanner/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since this workflow only needs to read the repository contents (e.g., to fetch Python files for linting), we will set `contents: read`. This ensures that the workflow has the minimum required permissions and avoids granting unnecessary write access.

The `permissions` block will be added immediately after the `name` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
